### PR TITLE
Fix reading speed from video and rearrange buttons

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -27,13 +27,13 @@
 
     <h1 class="mb-0 font-weight-bold text-white bg-dark p-4 ">Playback Speed Control</h1>
     <div class="text-center mt-3">
-      <button type="button" class="btn btn-success btn-arrow-right" id="increase-speed-btn">
-        <i class="bi bi-arrow-right-square"></i>
+      <button type="button" class="btn btn-warning btn-arrow-left" id="decrease-speed-btn">
+        <i class="bi bi-arrow-left-square"></i>
       </button>
       <!-- add spacing between buttons -->
       <span class="mx-3"></span>
-      <button type="button" class="btn btn-warning btn-arrow-left" id="decrease-speed-btn">
-        <i class="bi bi-arrow-left-square"></i>
+      <button type="button" class="btn btn-success btn-arrow-right" id="increase-speed-btn">
+        <i class="bi bi-arrow-right-square"></i>
       </button>
     </div>
     <p class="text-center mt-3 font-weight-bold text-uppercase text-white bg-dark p-2 ">Current Speed: <span id="current-speed">1x</span></p>

--- a/popup.js
+++ b/popup.js
@@ -3,6 +3,15 @@
 // import speedupVar from './speedupVar';
 
 var speedupVar = 1;
+chrome.tabs.executeScript({
+    code: 'document.querySelector("video").playbackRate',
+  },
+  (result) => {
+    speedupVar = result[0];
+    console.log("current speed:", speedupVar);
+    updateSpeed();
+  }
+);
 
 function updateSpeed() {
     document.getElementById("current-speed").textContent = speedupVar + "x";


### PR DESCRIPTION
Reads the current speed of the video and set it to speedVar. Previously, it would reset speed to 1 upon reopening extension.